### PR TITLE
Fixar av schemaformat samt markdown i dokumentation

### DIFF
--- a/documentation/common/Enumerationer.md
+++ b/documentation/common/Enumerationer.md
@@ -9,67 +9,67 @@ Dokument som laddas upp i CTIS har metainformation som berättar vad det är tä
 
 Det finns in data från produktionsmiljön flera exempel på där DisplayName förekommer både på engelska och på svenska. 
 
-typeCode        DisplayName                                                                   EPM       RBC
---------        -----------                                                                  -----     -----
-2	            Följebrev (ej för publicering)                                                           -
-3	            Proof of payment (for publication)                                                       -
-4	            Motivering till lågintervensionsprövning (för publicering)                               -
-5	            Protokoll (ej för publicering)                                                           ?
-7               Sammanfattning av protokoll (för publicering)                                            X
-8               DSMB (för publicering)                                                                   -
-9               Bevis på försäkringsskydd (för publicering)                                              -
-10              Finansiella bestämmelser                                                                 -
-11              Prövningsställenas lämplighet (för publicering)                                          ?
-12              CV för prövare (för publicering)                                                         -
-13              Prövarens lämplighet (för publicering)                                                   -
-14              Rekryteringsförfarande (för publicering)                                                 ?
-15              Försökspersonsinformation och informerat samtycke (för publicering)                      X
-16              Anteckningar från vetenskaplig rådgivning (för publicering)                              -
-17              PIP-utlåtande (för publicering)                                                          - 
-18              Prövarhandbok (för publicering)                                                          - 
-19              SmPC (för publicering)                                                                   - 
-20	            Authorisation of manufacturing and import (for publication)                              -
-41	            Final utredningsrapport del II (ej för publicering)                                      ?
-42              Final utredningsrapport del II (för publicering)                                         ?
-43	            Bilaga till ändringsansökan (för publicering)                                            -                                           
-49              Följebrev (för publicering)                                                              - 
-52	            Ändringsbeskrivning (för publicering)                                                    ?
-82	            Preliminär utredningsrapport - Del II                                                    ?
-86	            Preliminär utredningsrapport del I - Introduktion                                        -
-88	            Preliminär utredningsrapport del I - Preklinik                                           -
-89	            Preliminär utredningsrapport del I - Klinik                                              -
-90	            Preliminär utredningsrapport del I - Statistik                                           -
-91	            Preliminär utredningsrapport del I - Regulatorisk                                        -
-92	            Preliminär utredningsrapport del I - Sammanfattning                                      -
-104             Protokoll (för publicering)                                                              X 
-200             Studiedesign (för publicering)                                                           ? 
-215	            Bilaga (för publicering) (id215)                                                         ?
-226	            Bilaga från MS (för publicering)                                                         ?
-251             Lista över ändringar (för publicering)                                                   X 
-273             Final utredningsrapport del I kvalitet                                                   ? 
-274             Final utredningsrapport del I exklusive kvalitet (för publicering)                       ? 
-277             Följsamhet med nationella regler för dataskydd (för publicering)                         - 
-278             Följsamhet med regler för användning av biologiska prover (för publicering)              X 
-279	            Bilaga till Synpunkter (för publicering)                                                 -
-307	            Supporting documentation                                                                 -
-308	            Sammanfattning av protokoll (ej för publicering)                                         -
-310	            Studiedesign (ej för publicering)                                                        -
-311	            Anteckningar från vetenskaplig rådgivning (ej för publicering)                           -
-313	            Prövarhandbok (ej för publicering)                                                       -
-319	            Prövningsställenas lämplighet (ej för publicering)                                       -
-322	            Rekryteringsförfarande (ej för publicering)                                              -
-323	            Försökspersonsinformation och informerat samtycke (ej för publicering)                   -
-324	            Ändringsbeskrivning (ej för publicering)                                                 -
-325	            Bilaga (ej för publicering)(id325)                                                       -
-327	            Följsamhet med nationella regler för dataskydd (ej för publicering)                      -
-328	            Compliance with use of Biological samples (not for publication)                          -
-331	            IMPD (effekt och säkerhet) (ej för publicering)                                          -
-366	            Final utredningsrapport del I exklusive kvalitet (ej för publicering)                    - 
-370	            Bilaga(id370)                                                                            -
-371	            Bilaga till Synpunkt (ej för publicering)                                                -
-373	            List of Changes (not for publication)                                                    -
-387             Följsamhet med förordning (EU) 2016/679                                                  -
-388	            Följsamhet med förordning (EU) 2016/679 (ej för publicering)                             -
+|typeCode | DisplayName                                                                  | EPM | RBC |
+|---------| ------------                                                                 |-----|-----|
+|2	      | Följebrev (ej för publicering)                                               |     |  -  |
+|3	      | Proof of payment (for publication)                                           |     |  -  |
+|4	      | Motivering till lågintervensionsprövning (för publicering)                   |     |  -  |
+|5	      | Protokoll (ej för publicering)                                               |     |  ?  |
+|7        | Sammanfattning av protokoll (för publicering)                                |     |  X  |
+|8        | DSMB (för publicering)                                                       |     |  -  |
+|9        | Bevis på försäkringsskydd (för publicering)                                  |     |  -  |
+|10       | Finansiella bestämmelser                                                     |     |  -  |
+|11       | Prövningsställenas lämplighet (för publicering)                              |     |  ?  |
+|12       | CV för prövare (för publicering)                                             |     |  -  |
+|13       | Prövarens lämplighet (för publicering)                                       |     |  -  |
+|14       | Rekryteringsförfarande (för publicering)                                     |     |  ?  |
+|15       | Försökspersonsinformation och informerat samtycke (för publicering)          |     |  X  |
+|16       | Anteckningar från vetenskaplig rådgivning (för publicering)                  |     |  -  |
+|17       | PIP-utlåtande (för publicering)                                              |     |  -  | 
+|18       | Prövarhandbok (för publicering)                                              |     |  -  | 
+|19       | SmPC (för publicering)                                                       |     |  -  | 
+|20	      | Authorisation of manufacturing and import (for publication)                  |     |  -  |
+|41	      | Final utredningsrapport del II (ej för publicering)                          |     |  ?  |
+|42       | Final utredningsrapport del II (för publicering)                             |     |  ?  |
+|43	      | Bilaga till ändringsansökan (för publicering)                                |     |  -  |                                           
+|49       | Följebrev (för publicering)                                                  |     |  -  | 
+|52	      | Ändringsbeskrivning (för publicering)                                        |     |  ?  |
+|82	      | Preliminär utredningsrapport - Del II                                        |     |  ?  |
+|86	      | Preliminär utredningsrapport del I - Introduktion                            |     |  -  |
+|88	      | Preliminär utredningsrapport del I - Preklinik                               |     |  -  |
+|89	      | Preliminär utredningsrapport del I - Klinik                                  |     |  -  |
+|90	      | Preliminär utredningsrapport del I - Statistik                               |     |  -  |
+|91	      | Preliminär utredningsrapport del I - Regulatorisk                            |     |  -  |
+|92	      | Preliminär utredningsrapport del I - Sammanfattning                          |     |  -  |
+|104      | Protokoll (för publicering)                                                  |     |  X  | 
+|200      | Studiedesign (för publicering)                                               |     |  ?  | 
+|215	  | Bilaga (för publicering) (id215)                                             |     |  ?  |
+|226	  | Bilaga från MS (för publicering)                                             |     |  ?  |
+|251      | Lista över ändringar (för publicering)                                       |     |  X  | 
+|273      | Final utredningsrapport del I kvalitet                                       |     |  ?  | 
+|274      | Final utredningsrapport del I exklusive kvalitet (för publicering)           |     |  ?  | 
+|277      | Följsamhet med nationella regler för dataskydd (för publicering)             |     |  -  | 
+|278      | Följsamhet med regler för användning av biologiska prover (för publicering)  |     |  X  | 
+|279	  | Bilaga till Synpunkter (för publicering)                                     |     |  -  |
+|307	  | Supporting documentation                                                     |     |  -  |
+|308	  | Sammanfattning av protokoll (ej för publicering)                             |     |  -  |
+|310	  | Studiedesign (ej för publicering)                                            |     |  -  |
+|311	  | Anteckningar från vetenskaplig rådgivning (ej för publicering)               |     |  -  |
+|313	  | Prövarhandbok (ej för publicering)                                           |     |  -  |
+|319	  | Prövningsställenas lämplighet (ej för publicering)                           |     |  -  |
+|322	  | Rekryteringsförfarande (ej för publicering)                                  |     |  -  |
+|323	  | Försökspersonsinformation och informerat samtycke (ej för publicering)       |     |  -  |
+|324	  | Ändringsbeskrivning (ej för publicering)                                     |     |  -  |
+|325	  | Bilaga (ej för publicering)(id325)                                           |     |  -  |
+|327	  | Följsamhet med nationella regler för dataskydd (ej för publicering)          |     |  -  |
+|328	  | Compliance with use of Biological samples (not for publication)              |     |  -  |
+|331	  | IMPD (effekt och säkerhet) (ej för publicering)                              |     |  -  |
+|366	  | Final utredningsrapport del I exklusive kvalitet (ej för publicering)        |     |  -  | 
+|370	  | Bilaga(id370)                                                                |     |  -  |
+|371	  | Bilaga till Synpunkt (ej för publicering)                                    |     |  -  |
+|373	  | List of Changes (not for publication)                                        |     |  -  |
+|387      | Följsamhet med förordning (EU) 2016/679                                      |     |  -  |
+|388	  | Följsamhet med förordning (EU) 2016/679 (ej för publicering)                 |     |  -  |
 
 
 
@@ -78,21 +78,21 @@ Dokumenttyper samverkansdokument
 
 De dokument som används för att utbyta information mellan respektive organisationer kallas samverkansdokument. De är definierade enligt följande
 
-Typkod              Typ av dokument
-------              ------------------------------------
-samverk_1           Meddelandemetadata samarbetspartner                                        
-samverk_2           Strukturerad data från ansökan                                        
-samverk_3           Preliminär granskning del I                                        
-samverk_4           Preliminär granskning del II                                        
-samverk_5           Granskning av synpunkter från MSC                                        
-samverk_6           Yttrande del I                                        
-samverk_7           Yttrande del II                                        
-samverk_8           Underlag till invändning mot RMS slutsats                                        
-samverk_9           Synpunkt                                        
-samverk_10          RFI/RFI-svar                                        
-samverk_11          Ärendeinformation                                        
-9001                Beslutshandling                                        
-9006                Slutrapport
-9008	            Tjänsteanteckning		
+|Typkod      | Typ av dokument    |
+|------      | -------------------|
+|samverk_1   | Meddelandemetadata samarbetspartner                                        
+|samverk_2   | Strukturerad data från ansökan                                        
+|samverk_3   | Preliminär granskning del I                                        
+|samverk_4   | Preliminär granskning del II                                        
+|samverk_5   | Granskning av synpunkter från MSC                                        
+|samverk_6   | Yttrande del I                                        
+|samverk_7   | Yttrande del II                                        
+|samverk_8   | Underlag till invändning mot RMS slutsats                                        
+|samverk_9   | Synpunkt                                        
+|samverk_10  | RFI/RFI-svar                                        
+|samverk_11  | Ärendeinformation                                        
+|9001        | Beslutshandling                                        
+|9006        | Slutrapport
+|9008	     | Tjänsteanteckning		
 
 

--- a/src/schema/messageSchema.json
+++ b/src/schema/messageSchema.json
@@ -18,6 +18,8 @@
                     "type": "string",
                     "enum":
                     [
+                        "2.0",
+                        "2.1",
                         "2.2"
                     ]
                 },
@@ -102,7 +104,7 @@
                         "Notis: Ansökan tyst godkännande",
                         "Notis: Beslut för ansökan",
                         "Notis: Informell RFI",
-                        "Notis: Beslut för överflyttad prövning",
+                        "Notis: Beslut för överflyttad prövning"
                     ]
                 },
                 "dueDate":


### PR DESCRIPTION
Hade smugit sig med ett trailing komma