### PR TITLE
fix: formatted file using jq

### DIFF
--- a/src/schema/messageSchema.json
+++ b/src/schema/messageSchema.json
@@ -1,613 +1,545 @@
 {
-    "$schema": "https://json-schema.org/draft/2020-12/schema",
-    "$id": "https://github.com/Biobank-Sverige/clinical-trial-regulators-collaboration/schema/message",
-    "title": "Message",
-    "description": "Schema for message metadata version 3.0-SNAPSHOT",
-    "type": "object",
-    "properties":
-    {
-        "header":
-        {
-            "description": "Metadata som beskriver meddelandet självt",
-            "type": "object",
-            "properties":
-            {
-                "version":
-                {
-                    "description": "Version för det protokoll som versionen motsvarar.",
-                    "type": "string",
-                    "enum":
-                    [
-                        "3.0-SNAPSHOT"
-                    ]
-                },
-                "from":
-                {
-                    "description": "Avsändaren utryckt som en av ”LV”, ”EPM”, ”RBC”",
-                    "type": "string",
-                    "enum":
-                    [
-                        "LV",
-                        "EPM",
-                        "RBC"
-                    ]
-                },
-                "to":
-                {
-                    "description": "Mottagaren utryckt som en av ”LV”, ”EPM”, ”RBC”",
-                    "type": "string",
-                    "enum":
-                    [
-                        "LV",
-                        "EPM",
-                        "RBC"
-                    ]
-                },
-                "transactionId":
-                {
-                    "description": "Ett unikt id för meddelandet. Återanvänds inte även om meddelandet skickas om.",
-                    "type": "string"
-                },
-                "messageId":
-                {
-                    "description": "Ett id för meddelandet. Om ett meddelande behöver skickas om används samma messageId som på ursprungsmeddelandet.",
-                    "type": "string"
-                },
-                "parentMessageId":
-                {
-                    "description": "Används när ett meddelande är ett svar på ett annat meddelande. Sätt då till det värde messageId har i urspungsmeddelandet.",
-                    "type": ["string", "null"]
-                },
-                "timestamp":
-                {
-                    "description": "Tidpunkten när meddelandet skapas uttryckt enligt ISO-8601 med sekundupplösning.",
-                    "type": "string",
-                    "format": "date-time"
-                },
-                "messageReasonType":
-                {
-                    "description": "En text som beskriver varför meddelandet skickats.",
-                    "type": "string",
-                    "enum":
-                    [
-                        "Notis: Initial ansökan del I och II",
-                        "Notis: Initial ansökan del I",
-                        "Notis: Initial ansökan del II",
-                        "Notis: Ändringsansökan del I och II",
-                        "Notis: Ändringsansökan del I",
-                        "Notis: Ändringsansökan del II",
-                        "Notis: Valid ansökan",
-                        "Notis: Validerings-RFI till sponsor",
-                        "Begäran: Preliminär granskning del I",
-                        "Begäran: Preliminär granskning del II",
-                        "Svar: Preliminär granskning del I",
-                        "Svar: Preliminär granskning del II",
-                        "Begäran: Granskning av synpunkter från MSC",
-                        "Svar: Granskning av synpunkter från MSC",
-                        "Notis: Bedömnings-RFI del I till sponsor",
-                        "Notis: Bedömnings-RFI del II till sponsor",
-                        "Begäran: Yttrande del I",
-                        "Begäran: Yttrande del II",
-                        "Notis: Komplettering från sponsor del I",
-                        "Notis: Komplettering från sponsor del II",
-                        "Notis: Synpunkter från MSC efter komplettering del I",
-                        "Notis: Synpunkter från MSC efter komplettering del II",
-                        "Svar: Yttrande del I",
-                        "Svar: Yttrande del II",
-                        "Notis: AR och slutsats del I",
-                        "Notis: AR och slutsats del II",
-                        "Notis och kommentarsmöjlighet: AR och slutsats del I",
-                        "Notis och kommentarsmöjlighet: AR och slutsats del II",
-                        "Kommentar på notis: Underlag till invändning mot RMS slutsats",
-                        "Notis: Ansökan dragits tillbaka",
-                        "Notis: Ansökan förfallen",
-                        "Notis: Ansökan tyst godkännande",
-                        "Notis: Beslut för ansökan",
-                        "Notis: Informell RFI del I",
-                        "Notis: Informell RFI del II",
-                        "Notis: Informell RFI validering",
-                        "Notis: Beslut för överflyttad prövning"
-                    ]
-                },
-                "dueDate":
-                {
-                    "description": "Senaste datumet när avsändaren vill ha svar, uttryckt enligt ISO-8601 med datumupplösning. Null om inget svar förväntas.",
-                    "type": ["string", "null"],
-                    "format": "date"
-                }
-            },
-            "required":
-            [
-                "version",
-                "from",
-                "to",
-                "transactionId",
-                "messageId",
-                "timestamp",
-                "messageReasonType"
-            ]
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://github.com/Biobank-Sverige/clinical-trial-regulators-collaboration/schema/message",
+  "title": "Message",
+  "description": "Schema for message metadata version 3.0-SNAPSHOT",
+  "type": "object",
+  "properties": {
+    "header": {
+      "description": "Metadata som beskriver meddelandet självt",
+      "type": "object",
+      "properties": {
+        "version": {
+          "description": "Version för det protokoll som versionen motsvarar.",
+          "type": "string",
+          "enum": [
+            "3.0-SNAPSHOT"
+          ]
         },
-        "caseData":
-        {
-            "description": "Metadata gällande ansökningsärendet och dess behandling",
-            "type": "object",
-            "properties":
-            {
-                "lvDiaryNumber":
-                {
-                    "description": "Diarienummer från LV, unikt ID för varje ansökan. Används som korrelationsID för olika meddelanden i ett ärende.",
-                    "type": "string"
-                },
-                "domain":
-                {
-                    "description": "Kommer tillsvidare alltid vara ”HumMedProd” som ska utläsas ” läkemedel för människor”. Framtidssäkring eftersom vi vad det lider även kommer att skicka meddelanden som rör medicintekniska produkter och läkemedel för djur.",
-                    "type": "string",
-                    "enum":
-                    [
-                        "HumMedProd"
-                    ]
-                },
-                "caseType":
-                {
-                    "description": "Den ärendetyp som LV gett ärendet. Ska ge EPM/RBC tillräcklig information om vilken sorts ärende det är frågan om (multinationell eller bara Sverige? Del I, del II, eller båda? Nyansökan eller ändringsansökan?)",
-                    "type": "string",
-                    "enum":
-                    [
-                        "KP-ansökan, multinationell, initialt del I",
-                        "KP-ansökan, multinationell, initialt komplett",
-                        "KP-ansökan, multinationell, transitional",
-                        "KP-ansökan, mononationell, initialt del I",
-                        "KP-ansökan, mononationell, initialt komplett",
-                        "KP-ansökan, mononationell, transitional",			
-                        "KP-ansökan, Tillägg av SE som MSC",
-                        "Ändring, multinationell, del I",
-                        "Ändring, multinationell, del I och del II",
-                        "Ändring, mononationell, del I",
-                        "Ändring, mononationell, del I och del II",
-                        "Ändring, nationell, del II",
-                        "MDR -Ansökan 70.7a",
-                        "MDR -Ansökan 70.7b",
-                        "MDR -Anmälan 82/74.1",
-                        "IVD -Ansökan 66.7a",
-                        "IVD -Ansökan 66.7b",
-                        "IVD -Anmälan 70.1",
-                        "IVD -Anmälan 58.2",
-                        "MDR -Ändring av Ansökan 70.7a",
-                        "MDR -Ändring av Ansökan 70.7b",
-                        "MDR -Ändring av Anmälan 74.1",
-                        "MDR -Ändring av Anmälan 82",
-                        "IVD -Ändring av Ansökan 66.7a",
-                        "IVD -Ändring av Anmälan 70.1"
-                    ]
-                },
-                 "isTransitioned":
-                {
-                    "description": "Boolean som ger true om ärendet gäller en prövning som flyttats över från gamla reglementet. Finns bara med för det ärende som flyttar över prövningen, inte för efterkommande ändringsansökningar på den nyskapade kliniska prövningen",
-                    "type": "string",
-                    "enum":
-                    [
-                        "true",
-                        "false"
-                    ]
-                },
-                "transitionedFrom":
-                {
-                    "description": "EudtraCT-nummer på den tidigare prövningen.Finns bara med för det ärende som flyttar över prövningen, inte för efterkommande ändringsansökningar på den nyskapade kliniska prövningen",
-                    "type": ["string", "null"]
-                },
-                "decision":
-                {
-                    "description": "I fall där det finns ett beslut är utfallet noterat i detta element.",
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "enum": [
-                                "Avslag",
-                                "Avslut",
-                                "Bifall",
-                                "Avvisning",
-                                "Avskrivning"
-                            ]
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "decisionDetail":
-                {
-                    "description": "Ytterligare information om beslutet som fattats, i princip om det finns villkor alternativt motiv till avslag.",
-                    "oneOf": [
-                        {
-                            "type": "string",
-                            "enum": [
-                                "Bifall enligt ansökan i sin helhet",
-                                "Förutsättningar att bevilja ansökan saknas",
-                                "Nödvändig komplettering inte inkommen",
-                                "Ingen ytterligare åtgärd krävs",
-                                "Ansökan ej komplett eller annan formell brist",
-                                "Ansökan återtagen"
-                            ]
-                        },
-                        {
-                            "type": "null"
-                        }
-                    ]
-                },
-                "concernsEpm":
-                {
-                    "description": "Anger om ansökan rör EPM och RBC. Kan vara null om EMP:s/RBS:s medverkan inte ännu kunnat bestämmas.",
-                    "type": "string",
-                    "enum":
-                    [
-                        "true",
-                        "false"
-                    ]
-                },
-                "concernsRbc":
-                {
-                    "description": "Anger om ansökan rör EPM och RBC. Kan vara null om EMP:s/RBS:s medverkan inte ännu kunnat bestämmas.",
-                    "type": "string",
-                    "enum":
-                    [
-                        "true",
-                        "false"
-                    ]
-                },
-                "timetable":
-                {
-                    "description": "Lista på för RBC/EPM relevanta tidtabellshändelser så som LV planerar dem. Ska användas för att RBC/EPM ska kunna planera framtida bemanning.",
-                    "type": "array",
-                    "items":
-                    {
-                        "title": "Longitude and Latitude",
-                        "description": "Avgränsad aktivitet i handläggningen av en ansökan om prövningstillstånd för farmakologisk prövning.",
-                        "required":
-                        [
-                            "activity",
-                            "order"
-                        ],
-                        "type": "object",
-                        "properties":
-                        {
-                            "activity":
-                            {
-                                "description": "LV:s beskrivande text av tidtabellhändelsen",
-                                "type": "string"
-                            },
-                            "activityType":
-                            {
-                                "description": "LV:s interna typ på tidtabellhändelsen. Exempelvis \"start\", \"deadline\" eller \"meeting\".",
-                                "type": "string"
-                            },
-                            "status" : {
-                                "oneOf": [
-                                    {
-                                        "type": "string",
-                                        "enum": [
-                                            "Selected",
-                                            "Ongoing",
-                                            "Completed"
-                                        ]
-                                    },
-                                    {
-                                        "type": "null"
-                                    }
-                                ]
-                            },
-                            "key": {
-                                "description": "En nyckel till tidtabellshändelsen i LV:s ärendehanteringssystem.",
-                                "type": "string"
-                            },
-                            "order":
-                            {
-                                "description": "Sorteringsordning av tidtabellhändelserna. I dokumentet kan händelserna komma osorterade.",
-                                "type": "integer",
-                                "inclusiveMinimum": 0
-                            },
-                            "plannedEndDate":
-                            {
-                                "description": "Det planerade datumet då tidtabellhändelsen ska avslutas, uttryckt enligt ISO-8601 med datumupplösning.",
-                                "type": ["string", "null"],
-                                "format": "date"
-                            },
-                            "actualEndDate":
-                            {
-                                "description": "Det datum då tidtabellhändelsen faktiskt avslutades, uttryckt enligt ISO-8601 med datumupplösning.",
-                                "type": ["string", "null"],
-                                "format": "date"
-                            }
-                        }
-                    }
-                }
-            },
-            "required": ["lvDiaryNumber", "caseType"]
+        "from": {
+          "description": "Avsändaren utryckt som en av ”LV”, ”EPM”, ”RBC”",
+          "type": "string",
+          "enum": [
+            "LV",
+            "EPM",
+            "RBC"
+          ]
         },
-        "clinicalTrialData":
-        {
-            "description": "Innehåller vissa översiktsdata om prövningen.",
-            "type": "object",
-            "properties":
-            {
-                "clinicalTrialId":
-                {
-                    "description": "Prövningens id i CTIS-portalen",
-                    "type": "string"
-                },
-                "emaSubmissionDate":
-                {
-                    "description": "Datum då ansökan skickades in till ctis-portalen.",
-                    "type": ["string", "null"],
-                    "format": "date"
-                },
-                "swedenRole":
-                {
-                    "description": "Sveriges aktuella RMS/MSC-status i prövningen. Kan uppdateras under valideringsfasen.",
-                    "type": "string",
-                    "enum":
-                    [
-                        "Föreslagen MSC",
-                        "Föreslagen RMS",
-                        "MSC",
-                        "RMS"
-                    ]
-                },
-                "memberstateConcerned":
-                {
-                    "description": "En lista på alla deltagande länder i prövningen.",
-                    "type": "array",
-                    "items":
-                    {
-                        "type": "string"
-                    },
-                    "minItems": 1,
-                    "uniqueItems": true
-                },
-                "sponsor":
-                {
-                    "type": "object",
-                    "properties":
-                    {
-                        "name":
-                        {
-                            "description": "Huvudsponsorns namn baserat på vad som angivits i CTIS-portalen",
-                            "type": "string"
-                        },
-                        "country":
-                        {
-                            "description": "Sponsors ort som angivits i adressen.",
-                            "type": "string"
-                        }
-                    }
-                },
-                "part1Data":
-                {
-                    "description": "Huvudobjekt för detaljerade data om prövningen gemensam för alla MSC.",
-                    "type": "object",
-                    "properties":
-                    {
-                        "title":
-                        {
-                            "description": "Prövningens officiella titel",
-                            "type": "string"
-                        }
-                    }
-                },
-                "swedishPart2Data":
-                {
-                    "description": "Huvudobjekt för data om prövningen som bara berör Sverige.",
-                    "type": "object",
-                    "properties":
-                    {
-                        "trialSites":
-                        {
-                            "description": "En lista med alla prövningsställen i Sverige",
-                            "type": "array",
-                            "items":
-                            {
-                                "trialSiteName":
-                                {
-                                    "description": "Namnet på prövningsstället. Värdet kommer tillsvidare alltid vara null eftersom det är så det skickas ut från CTIS.",
-                                    "type": "string"
-                                },
-                                "department":
-                                {
-                                    "description": "Ett fritextfält",
-                                    "type": "string"
-                                },
-                                "organisationAddress":
-                                {
-                                    "description": "Adressinformation enligt EMA:s SPOR-databas",
-                                    "type": "object",
-                                    "properties":
-                                    {
-                                        "addressLine1":
-                                        {
-                                            "description": "Adressrad 1",
-                                            "type": "string"
-                                        },
-                                        "addressLine2":
-                                        {
-                                            "description": "Adressrad 2",
-                                            "type": "string"
-                                        },
-                                        "addressLine3":
-                                        {
-                                            "description": "Adressrad 3",
-                                            "type": "string"
-                                        },
-                                        "addressLine4":
-                                        {
-                                            "description": "Adressrad 4",
-                                            "type": "string"
-                                        },
-                                        "postalCode":
-                                        {
-                                            "description": "Postnummer ",
-                                            "type": "string"
-                                        },
-                                        "city":
-                                        {
-                                            "description": "Ort",
-                                            "type": "string"
-                                        }
-                                    }
-                                },
-                                "principalInvestigator":
-                                {
-                                    "description": "Prövningsställets huvudprövares kontaktuppgifter.",
-                                    "type": "object",
-                                    "properties":
-                                    {
-                                        "familyName":
-                                        {
-                                            "description": "Efternamn",
-                                            "type": "string"
-                                        },
-                                        "givenName":
-                                        {
-                                            "description": "Förnamn",
-                                            "type": "string"
-                                        },
-                                        "phoneNumber":
-                                        {
-                                            "description": "Telefonnummer",
-                                            "type": "string"
-                                        },
-                                        "emailAddress":
-                                        {
-                                            "description": "E-postadress",
-                                            "type": "string"
-                                        }
-                                    }
-                                }
-                            }
-                        }
-                    }
-                }
-            }
+        "to": {
+          "description": "Mottagaren utryckt som en av ”LV”, ”EPM”, ”RBC”",
+          "type": "string",
+          "enum": [
+            "LV",
+            "EPM",
+            "RBC"
+          ]
         },
-        "emaDocuments":
-        {
-            "description": "Lista på metadata om dokument från ctis",
-            "type": "array",
-            "items":
-            {
-                "description": "Struktur för beskrivningen av bifogade dokument som hämtats ur CTIS.",
-                "type": "object",
-                "properties":
-                {
-                    "filename":
-                    {
-                        "description": "Filnamnet på dokumentet",
-                        "type": "string"
-                    },
-                    "applicationPart":
-                    {
-                        "description": "Om dokumentet tillhör del I eller del II, representerad som ”1” eller ”2”. Observera att även ”” förekommer, vilket är rapporterat som bug hos CTIS/EMA.",
-                        "type": "string"
-                    },
-                    "systemVersion":
-                    {
-                        "description": "Version som uppdateras varje gång dokumentet laddas upp i CTIS-portalen",
-                        "type": "string"
-                    },
-                    "documentType":
-                    {
-                        "description": "Benämning på dokumentet i CTIS-portalen. Alla dokument CTIS-portalen är hårt typade och representeras av en kod och ett “DisplayName”. En sponsor kan inte lägga till godtyckliga dokument, men kan lägga till flera dokument av varje tillåten typ.",
-                        "type": "object",
-                        "properties":
-                        {
-                            "code":
-                            {
-                                "description": "Dokumenttypens kod",
-                                "type": "string"
-                            }
-                        },
-                        "displayName":
-                        {
-                            "description": "displayName uttrycks på svenska och kan användas för att beskriva bilagorna för handläggarna. Mängden av dokumenttyper som finns tillgängliga är inte bunden utan kan utökas efter hand.",
-                            "type": "string"
-                        },
-                        "required":
-                        [
-                            "code",
-                            "displayName"
-                        ]
-                    }
-                },
-                "required": ["filename", "documentType"]
-            }
+        "transactionId": {
+          "description": "Ett unikt id för meddelandet. Återanvänds inte även om meddelandet skickas om.",
+          "type": "string"
         },
-        "otherDocuments":
-        {
-            "description": "Lista med metadata om samverkansdokument som finns i meddelandet. Skall i samtliga fall vara minst 4 stycken, 'message.json', 'message.htm', 'ctisMetadata.json' och 'ctismetadata.htm'",
-            "type": "array",
-            "items":
-            {
-                "title": ":Övriga dokumenten",
-                "description": "Struktur för beskrivningen av bifogade samverkansdokument.",
-                "type": "object",
-                "properties":
-                {
-                    "filename":
-                    {
-                        "description": "Filnamn på dokumentet",
-                        "type": "string"
-                    },
-                    "documentType":
-                    {
-                        "description": "Typ av handling som bilagan utgör",
-                        "type": "object",
-                        "properties":
-                        {
-                            "code":
-                            {
-                                "description": "Dokumenttypens kod",
-                                "type": "string",
-                                "enum":
-                                [
-                                    "samverk_1",
-                                    "samverk_2",
-                                    "samverk_3",
-                                    "samverk_4",
-                                    "samverk_5",
-                                    "samverk_6",
-                                    "samverk_7",
-                                    "samverk_8",
-                                    "samverk_9",
-                                    "samverk_10",
-                                    "samverk_11",
-                                    "9001"
-                                ]
-                            },
-                            "displayName":
-                            {
-                                "description": "Benämning på de dokument som LV, RBC och EPM skapar. Alla dokument ska vara typade",
-                                "type": "string",
-                                "enum":
-                                [
-                                    "Meddelandemetadata samarbetspartner",
-                                    "Strukturerad data från ansökan",
-                                    "Preliminär granskning del I",
-                                    "Preliminär granskning del II",
-                                    "Granskning av synpunkter från MSC",
-                                    "Yttrande del I",
-                                    "Yttrande del II",
-                                    "Underlag till invändning mot RMS slutsats",
-                                    "Synpunkt",
-                                    "RFI/RFI-svar",
-                                    "Ärendeinformation",
-                                    "Beslutshandling"
-                                ]
-                            }
-                        },
-                        "required": ["code", "displayName"]
-                    }
-                },
-                "required": ["filename", "documentType"]
-            },
-            "minItems": 4
+        "messageId": {
+          "description": "Ett id för meddelandet. Om ett meddelande behöver skickas om används samma messageId som på ursprungsmeddelandet.",
+          "type": "string"
+        },
+        "parentMessageId": {
+          "description": "Används när ett meddelande är ett svar på ett annat meddelande. Sätt då till det värde messageId har i urspungsmeddelandet.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "timestamp": {
+          "description": "Tidpunkten när meddelandet skapas uttryckt enligt ISO-8601 med sekundupplösning.",
+          "type": "string",
+          "format": "date-time"
+        },
+        "messageReasonType": {
+          "description": "En text som beskriver varför meddelandet skickats.",
+          "type": "string",
+          "enum": [
+            "Notis: Initial ansökan del I och II",
+            "Notis: Initial ansökan del I",
+            "Notis: Initial ansökan del II",
+            "Notis: Ändringsansökan del I och II",
+            "Notis: Ändringsansökan del I",
+            "Notis: Ändringsansökan del II",
+            "Notis: Valid ansökan",
+            "Notis: Validerings-RFI till sponsor",
+            "Begäran: Preliminär granskning del I",
+            "Begäran: Preliminär granskning del II",
+            "Svar: Preliminär granskning del I",
+            "Svar: Preliminär granskning del II",
+            "Begäran: Granskning av synpunkter från MSC",
+            "Svar: Granskning av synpunkter från MSC",
+            "Notis: Bedömnings-RFI del I till sponsor",
+            "Notis: Bedömnings-RFI del II till sponsor",
+            "Begäran: Yttrande del I",
+            "Begäran: Yttrande del II",
+            "Notis: Komplettering från sponsor del I",
+            "Notis: Komplettering från sponsor del II",
+            "Notis: Synpunkter från MSC efter komplettering del I",
+            "Notis: Synpunkter från MSC efter komplettering del II",
+            "Svar: Yttrande del I",
+            "Svar: Yttrande del II",
+            "Notis: AR och slutsats del I",
+            "Notis: AR och slutsats del II",
+            "Notis och kommentarsmöjlighet: AR och slutsats del I",
+            "Notis och kommentarsmöjlighet: AR och slutsats del II",
+            "Kommentar på notis: Underlag till invändning mot RMS slutsats",
+            "Notis: Ansökan dragits tillbaka",
+            "Notis: Ansökan förfallen",
+            "Notis: Ansökan tyst godkännande",
+            "Notis: Beslut för ansökan",
+            "Notis: Informell RFI del I",
+            "Notis: Informell RFI del II",
+            "Notis: Informell RFI validering",
+            "Notis: Beslut för överflyttad prövning"
+          ]
+        },
+        "dueDate": {
+          "description": "Senaste datumet när avsändaren vill ha svar, uttryckt enligt ISO-8601 med datumupplösning. Null om inget svar förväntas.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
         }
+      },
+      "required": [
+        "version",
+        "from",
+        "to",
+        "transactionId",
+        "messageId",
+        "timestamp",
+        "messageReasonType"
+      ]
+    },
+    "caseData": {
+      "description": "Metadata gällande ansökningsärendet och dess behandling",
+      "type": "object",
+      "properties": {
+        "lvDiaryNumber": {
+          "description": "Diarienummer från LV, unikt ID för varje ansökan. Används som korrelationsID för olika meddelanden i ett ärende.",
+          "type": "string"
+        },
+        "domain": {
+          "description": "Kommer tillsvidare alltid vara ”HumMedProd” som ska utläsas ” läkemedel för människor”. Framtidssäkring eftersom vi vad det lider även kommer att skicka meddelanden som rör medicintekniska produkter och läkemedel för djur.",
+          "type": "string",
+          "enum": [
+            "HumMedProd"
+          ]
+        },
+        "caseType": {
+          "description": "Den ärendetyp som LV gett ärendet. Ska ge EPM/RBC tillräcklig information om vilken sorts ärende det är frågan om (multinationell eller bara Sverige? Del I, del II, eller båda? Nyansökan eller ändringsansökan?)",
+          "type": "string",
+          "enum": [
+            "KP-ansökan, multinationell, initialt del I",
+            "KP-ansökan, multinationell, initialt komplett",
+            "KP-ansökan, multinationell, transitional",
+            "KP-ansökan, mononationell, initialt del I",
+            "KP-ansökan, mononationell, initialt komplett",
+            "KP-ansökan, mononationell, transitional",
+            "KP-ansökan, Tillägg av SE som MSC",
+            "Ändring, multinationell, del I",
+            "Ändring, multinationell, del I och del II",
+            "Ändring, mononationell, del I",
+            "Ändring, mononationell, del I och del II",
+            "Ändring, nationell, del II",
+            "MDR -Ansökan 70.7a",
+            "MDR -Ansökan 70.7b",
+            "MDR -Anmälan 82/74.1",
+            "IVD -Ansökan 66.7a",
+            "IVD -Ansökan 66.7b",
+            "IVD -Anmälan 70.1",
+            "IVD -Anmälan 58.2",
+            "MDR -Ändring av Ansökan 70.7a",
+            "MDR -Ändring av Ansökan 70.7b",
+            "MDR -Ändring av Anmälan 74.1",
+            "MDR -Ändring av Anmälan 82",
+            "IVD -Ändring av Ansökan 66.7a",
+            "IVD -Ändring av Anmälan 70.1"
+          ]
+        },
+        "isTransitioned": {
+          "description": "Boolean som ger true om ärendet gäller en prövning som flyttats över från gamla reglementet. Finns bara med för det ärende som flyttar över prövningen, inte för efterkommande ändringsansökningar på den nyskapade kliniska prövningen",
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        },
+        "transitionedFrom": {
+          "description": "EudtraCT-nummer på den tidigare prövningen.Finns bara med för det ärende som flyttar över prövningen, inte för efterkommande ändringsansökningar på den nyskapade kliniska prövningen",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "decision": {
+          "description": "I fall där det finns ett beslut är utfallet noterat i detta element.",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Avslag",
+                "Avslut",
+                "Bifall",
+                "Avvisning",
+                "Avskrivning"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "decisionDetail": {
+          "description": "Ytterligare information om beslutet som fattats, i princip om det finns villkor alternativt motiv till avslag.",
+          "oneOf": [
+            {
+              "type": "string",
+              "enum": [
+                "Bifall enligt ansökan i sin helhet",
+                "Förutsättningar att bevilja ansökan saknas",
+                "Nödvändig komplettering inte inkommen",
+                "Ingen ytterligare åtgärd krävs",
+                "Ansökan ej komplett eller annan formell brist",
+                "Ansökan återtagen"
+              ]
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "concernsEpm": {
+          "description": "Anger om ansökan rör EPM och RBC. Kan vara null om EMP:s/RBS:s medverkan inte ännu kunnat bestämmas.",
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        },
+        "concernsRbc": {
+          "description": "Anger om ansökan rör EPM och RBC. Kan vara null om EMP:s/RBS:s medverkan inte ännu kunnat bestämmas.",
+          "type": "string",
+          "enum": [
+            "true",
+            "false"
+          ]
+        },
+        "timetable": {
+          "description": "Lista på för RBC/EPM relevanta tidtabellshändelser så som LV planerar dem. Ska användas för att RBC/EPM ska kunna planera framtida bemanning.",
+          "type": "array",
+          "items": {
+            "title": "Longitude and Latitude",
+            "description": "Avgränsad aktivitet i handläggningen av en ansökan om prövningstillstånd för farmakologisk prövning.",
+            "required": [
+              "activity",
+              "order"
+            ],
+            "type": "object",
+            "properties": {
+              "activity": {
+                "description": "LV:s beskrivande text av tidtabellhändelsen",
+                "type": "string"
+              },
+              "activityType": {
+                "description": "LV:s interna typ på tidtabellhändelsen. Exempelvis \"start\", \"deadline\" eller \"meeting\".",
+                "type": "string"
+              },
+              "status": {
+                "oneOf": [
+                  {
+                    "type": "string",
+                    "enum": [
+                      "Selected",
+                      "Ongoing",
+                      "Completed"
+                    ]
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              },
+              "key": {
+                "description": "En nyckel till tidtabellshändelsen i LV:s ärendehanteringssystem.",
+                "type": "string"
+              },
+              "order": {
+                "description": "Sorteringsordning av tidtabellhändelserna. I dokumentet kan händelserna komma osorterade.",
+                "type": "integer",
+                "inclusiveMinimum": 0
+              },
+              "plannedEndDate": {
+                "description": "Det planerade datumet då tidtabellhändelsen ska avslutas, uttryckt enligt ISO-8601 med datumupplösning.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date"
+              },
+              "actualEndDate": {
+                "description": "Det datum då tidtabellhändelsen faktiskt avslutades, uttryckt enligt ISO-8601 med datumupplösning.",
+                "type": [
+                  "string",
+                  "null"
+                ],
+                "format": "date"
+              }
+            }
+          }
+        }
+      },
+      "required": [
+        "lvDiaryNumber",
+        "caseType"
+      ]
+    },
+    "clinicalTrialData": {
+      "description": "Innehåller vissa översiktsdata om prövningen.",
+      "type": "object",
+      "properties": {
+        "clinicalTrialId": {
+          "description": "Prövningens id i CTIS-portalen",
+          "type": "string"
+        },
+        "emaSubmissionDate": {
+          "description": "Datum då ansökan skickades in till ctis-portalen.",
+          "type": [
+            "string",
+            "null"
+          ],
+          "format": "date"
+        },
+        "swedenRole": {
+          "description": "Sveriges aktuella RMS/MSC-status i prövningen. Kan uppdateras under valideringsfasen.",
+          "type": "string",
+          "enum": [
+            "Föreslagen MSC",
+            "Föreslagen RMS",
+            "MSC",
+            "RMS"
+          ]
+        },
+        "memberstateConcerned": {
+          "description": "En lista på alla deltagande länder i prövningen.",
+          "type": "array",
+          "items": {
+            "type": "string"
+          },
+          "minItems": 1,
+          "uniqueItems": true
+        },
+        "sponsor": {
+          "type": "object",
+          "properties": {
+            "name": {
+              "description": "Huvudsponsorns namn baserat på vad som angivits i CTIS-portalen",
+              "type": "string"
+            },
+            "country": {
+              "description": "Sponsors ort som angivits i adressen.",
+              "type": "string"
+            }
+          }
+        },
+        "part1Data": {
+          "description": "Huvudobjekt för detaljerade data om prövningen gemensam för alla MSC.",
+          "type": "object",
+          "properties": {
+            "title": {
+              "description": "Prövningens officiella titel",
+              "type": "string"
+            }
+          }
+        },
+        "swedishPart2Data": {
+          "description": "Huvudobjekt för data om prövningen som bara berör Sverige.",
+          "type": "object",
+          "properties": {
+            "trialSites": {
+              "description": "En lista med alla prövningsställen i Sverige",
+              "type": "array",
+              "items": {
+                "trialSiteName": {
+                  "description": "Namnet på prövningsstället. Värdet kommer tillsvidare alltid vara null eftersom det är så det skickas ut från CTIS.",
+                  "type": "string"
+                },
+                "department": {
+                  "description": "Ett fritextfält",
+                  "type": "string"
+                },
+                "organisationAddress": {
+                  "description": "Adressinformation enligt EMA:s SPOR-databas",
+                  "type": "object",
+                  "properties": {
+                    "addressLine1": {
+                      "description": "Adressrad 1",
+                      "type": "string"
+                    },
+                    "addressLine2": {
+                      "description": "Adressrad 2",
+                      "type": "string"
+                    },
+                    "addressLine3": {
+                      "description": "Adressrad 3",
+                      "type": "string"
+                    },
+                    "addressLine4": {
+                      "description": "Adressrad 4",
+                      "type": "string"
+                    },
+                    "postalCode": {
+                      "description": "Postnummer ",
+                      "type": "string"
+                    },
+                    "city": {
+                      "description": "Ort",
+                      "type": "string"
+                    }
+                  }
+                },
+                "principalInvestigator": {
+                  "description": "Prövningsställets huvudprövares kontaktuppgifter.",
+                  "type": "object",
+                  "properties": {
+                    "familyName": {
+                      "description": "Efternamn",
+                      "type": "string"
+                    },
+                    "givenName": {
+                      "description": "Förnamn",
+                      "type": "string"
+                    },
+                    "phoneNumber": {
+                      "description": "Telefonnummer",
+                      "type": "string"
+                    },
+                    "emailAddress": {
+                      "description": "E-postadress",
+                      "type": "string"
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "emaDocuments": {
+      "description": "Lista på metadata om dokument från ctis",
+      "type": "array",
+      "items": {
+        "description": "Struktur för beskrivningen av bifogade dokument som hämtats ur CTIS.",
+        "type": "object",
+        "properties": {
+          "filename": {
+            "description": "Filnamnet på dokumentet",
+            "type": "string"
+          },
+          "applicationPart": {
+            "description": "Om dokumentet tillhör del I eller del II, representerad som ”1” eller ”2”. Observera att även ”” förekommer, vilket är rapporterat som bug hos CTIS/EMA.",
+            "type": "string"
+          },
+          "systemVersion": {
+            "description": "Version som uppdateras varje gång dokumentet laddas upp i CTIS-portalen",
+            "type": "string"
+          },
+          "documentType": {
+            "description": "Benämning på dokumentet i CTIS-portalen. Alla dokument CTIS-portalen är hårt typade och representeras av en kod och ett “DisplayName”. En sponsor kan inte lägga till godtyckliga dokument, men kan lägga till flera dokument av varje tillåten typ.",
+            "type": "object",
+            "properties": {
+              "code": {
+                "description": "Dokumenttypens kod",
+                "type": "string"
+              }
+            },
+            "displayName": {
+              "description": "displayName uttrycks på svenska och kan användas för att beskriva bilagorna för handläggarna. Mängden av dokumenttyper som finns tillgängliga är inte bunden utan kan utökas efter hand.",
+              "type": "string"
+            },
+            "required": [
+              "code",
+              "displayName"
+            ]
+          }
+        },
+        "required": [
+          "filename",
+          "documentType"
+        ]
+      }
+    },
+    "otherDocuments": {
+      "description": "Lista med metadata om samverkansdokument som finns i meddelandet. Skall i samtliga fall vara minst 4 stycken, 'message.json', 'message.htm', 'ctisMetadata.json' och 'ctismetadata.htm'",
+      "type": "array",
+      "items": {
+        "title": ":Övriga dokumenten",
+        "description": "Struktur för beskrivningen av bifogade samverkansdokument.",
+        "type": "object",
+        "properties": {
+          "filename": {
+            "description": "Filnamn på dokumentet",
+            "type": "string"
+          },
+          "documentType": {
+            "description": "Typ av handling som bilagan utgör",
+            "type": "object",
+            "properties": {
+              "code": {
+                "description": "Dokumenttypens kod",
+                "type": "string",
+                "enum": [
+                  "samverk_1",
+                  "samverk_2",
+                  "samverk_3",
+                  "samverk_4",
+                  "samverk_5",
+                  "samverk_6",
+                  "samverk_7",
+                  "samverk_8",
+                  "samverk_9",
+                  "samverk_10",
+                  "samverk_11",
+                  "9001"
+                ]
+              },
+              "displayName": {
+                "description": "Benämning på de dokument som LV, RBC och EPM skapar. Alla dokument ska vara typade",
+                "type": "string",
+                "enum": [
+                  "Meddelandemetadata samarbetspartner",
+                  "Strukturerad data från ansökan",
+                  "Preliminär granskning del I",
+                  "Preliminär granskning del II",
+                  "Granskning av synpunkter från MSC",
+                  "Yttrande del I",
+                  "Yttrande del II",
+                  "Underlag till invändning mot RMS slutsats",
+                  "Synpunkt",
+                  "RFI/RFI-svar",
+                  "Ärendeinformation",
+                  "Beslutshandling"
+                ]
+              }
+            },
+            "required": [
+              "code",
+              "displayName"
+            ]
+          }
+        },
+        "required": [
+          "filename",
+          "documentType"
+        ]
+      },
+      "minItems": 4
     }
+  }
 }


### PR DESCRIPTION
När jag började titta närmare på filen såg jag att filen hade Allman-braces vilket inte är standard i JSON.

Formatterade med `jq`, i övrigt inga ändringar. `jq` finns tillgängligt i alla miljöer och är konsekvent.