### PR TITLE
fix: Version number should still be 3 in main

### DIFF
--- a/src/schema/messageSchema.json
+++ b/src/schema/messageSchema.json
@@ -32,7 +32,9 @@
                         "description": "Schemat hanteras i versioner och elementet version säger vilken version av schemat som meddelandet skall följa. Majorversioner skall vara bakåtkompatibla så att en högre minorversion inte stör tolkningen av en tidigare.",
                         "type": "string",
                         "enum": [
-                            "4-SNAPSHOT"
+                            "3.0",
+                            "3.0.1",
+                            "3.0.2"
                         ]
                     },
                     "from": {


### PR DESCRIPTION
Enligt diskussionen i #12 och semantic versioning så borde nog den typo-fix som mergades häromdagen blivit v3.0.1.

Denna PR fixar det, och kan sen taggas som v3.0.2 (då föregående commit redan står som v3.0.1).

Jag ber om ursäkt om vi missförstått hur `version`-enumen är tänkt att fungera. Jag tänker det som att den innehåller de minor- och patch-versioner som är giltiga att vara "in flight", så att säga. Detta för att tillåta att LV skickar meddelanden som 3.2.3 även om senaste patchen är 3.2.5 t ex.

Eller har ni någon annan bra tanke där?